### PR TITLE
add missing dll to post build

### DIFF
--- a/Mandrill_UI/Mandrill_UI.csproj
+++ b/Mandrill_UI/Mandrill_UI.csproj
@@ -393,11 +393,13 @@ if $(Configuration) == 20 goto Build20
 :Build13
 echo Copying results to 1.3
 xcopy /Q/Y "$(TargetDir)Mandrill_UI.customization.dll" "C:\Users\ksobon\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\Archi-lab_Mandrill\bin"
+xcopy /Q/Y "$(TargetDir)HtmlAgilityPack.dll" "C:\Users\ksobon\AppData\Roaming\Dynamo\Dynamo Revit\1.3\packages\Archi-lab_Mandrill\bin"
 goto exit
 
 :Build20
 echo Copying results to 2.0
 xcopy /Q/Y "$(TargetDir)Mandrill_UI.customization.dll" "C:\Users\ksobon\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
+xcopy /Q/Y "$(TargetDir)HtmlAgilityPack.dll" "C:\Users\ksobon\AppData\Roaming\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
 goto exit
 
 :exit


### PR DESCRIPTION
this should be fixed by adding the file to post build: https://github.com/BadMonkeysTeam/Mandrill/issues/42

I also published a new version of the package: 2018.0.1

