### PR TITLE
no fody but general cleanup of post builds and referenced assemblies

### DIFF
--- a/Mandrill/Mandrill_Dynamo.csproj
+++ b/Mandrill/Mandrill_Dynamo.csproj
@@ -140,63 +140,63 @@
   <ItemGroup>
     <Reference Include="Analysis, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.DynamoCoreNodes.2.0.0.4714\lib\net45\Analysis.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="CoreNodeModels, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.2.0.0.4714\lib\net45\CoreNodeModels.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="CoreNodeModelsWpf, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.2.0.0.4714\lib\net45\CoreNodeModelsWpf.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DesignScriptBuiltin, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DesignScriptBuiltin.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DSCoreNodes, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.DynamoCoreNodes.2.0.0.4714\lib\net45\DSCoreNodes.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DSIronPython, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DSIronPython.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoApplications, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoApplications.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCore, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoCore.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCoreWpf, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.2.0.0.4714\lib\net45\DynamoCoreWpf.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoInstallDetective, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoInstallDetective.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoServices, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.2.0.0.4714\lib\net45\DynamoServices.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoShapeManager, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoShapeManager.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUnits, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.0.4714\lib\net45\DynamoUnits.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUtilities, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoUtilities.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="GeometryColor, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.DynamoCoreNodes.2.0.0.4714\lib\net45\GeometryColor.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="HtmlRenderer, Version=1.5.0.6, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlRenderer.Core.1.5.0.6\lib\net45\HtmlRenderer.dll</HintPath>
@@ -220,23 +220,22 @@
     </Reference>
     <Reference Include="Microsoft.Practices.Prism, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Practices.Prism.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.Prism.Interactivity, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Practices.Prism.Interactivity.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="PdfSharp, Version=1.32.3057.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
       <HintPath>..\packages\PDFsharp.1.32.3057.0\lib\net20\PdfSharp.dll</HintPath>
@@ -250,11 +249,11 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="ProtoCore, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\ProtoCore.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.0.4714\lib\net45\ProtoGeometry.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Select.HtmlToPdf, Version=2.3.0.0, Culture=neutral, PublicKeyToken=e0ae9f6e27a97018, processorArchitecture=MSIL">
       <HintPath>..\packages\Select.HtmlToPdf.2.3.0.0\lib\net40\Select.HtmlToPdf.dll</HintPath>
@@ -280,7 +279,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="VMDataBridge, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\VMDataBridge.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -313,14 +312,17 @@
     <ProjectReference Include="..\Mandrill_d3\Mandrill_d3.csproj">
       <Project>{63ed27cd-0302-4240-b322-990e76dbac42}</Project>
       <Name>Mandrill_d3</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Mandrill_Types\Mandrill_Types.csproj">
       <Project>{cddd1df6-1a31-4960-be81-62fd692f2a82}</Project>
       <Name>Mandrill_Types</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Mandrill_UI\Mandrill_UI.csproj">
       <Project>{c665e3fe-575e-4e8a-9284-359def02a553}</Project>
       <Name>Mandrill_UI</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -689,18 +691,8 @@
     <Error Condition="!Exists('..\packages\Select.HtmlToPdf.2.3.0.0\build\Select.HtmlToPdf.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Select.HtmlToPdf.2.3.0.0\build\Select.HtmlToPdf.targets'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Q/Y "$(TargetPath)" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)$(TargetName).XML" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)Mandrill_d3.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)Mandrill_Types.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)Mandrill_Types.xml" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)Mandrill_UI.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)Mandrill_UI.xml" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)RazorEngine.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)Select.HtmlToPdf.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)Select.Html.dep" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\extra"
-xcopy /Q/Y "$(TargetDir)Archi-lab_Mandrill.customization.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)Newtonsoft.Json.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Target Name="BeforeBuild">
     <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v2.0">
@@ -710,5 +702,34 @@ xcopy /Q/Y "$(TargetDir)Newtonsoft.Json.dll" "%25AppData%25\Dynamo\Dynamo Revit\
     <AL TargetType="library" EmbedResources="$(ProjectDir)Archi-lab_MandrillImages.resources" OutputAssembly="$(OutDir)Archi-lab_Mandrill.customization.dll" />
   </Target>
   <Target Name="AfterBuild">
+  </Target>
+  <Target Name="CopyFiles" AfterTargets="AfterBuild;NonWinFodyTarget">
+    <Message Text="Copy files..." Importance="high" />
+    <Message Text="" Importance="high" />
+    <Message Text="$(TargetPath) copied to Dynamo\Packages" Importance="high" />
+    <Message Text="$(TargetPath) copied to Grasshopper\\Libraries" Importance="high" />
+    
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).xml" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).customization.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlRenderer.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlRenderer.WinForms.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlRenderer.WPF.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlRenderer.PdfSharp.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)PdfSharp.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)PdfSharp.Charting.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Microsoft.Practices.ServiceLocation.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)System.Windows.Interactivity.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Microsoft.Expression.Interactions.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    
+    <Copy SourceFiles="$(TargetDir)HtmlRenderer.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlRenderer.WinForms.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlRenderer.WPF.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlRenderer.PdfSharp.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)PdfSharp.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)PdfSharp.Charting.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Microsoft.Practices.ServiceLocation.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)System.Windows.Interactivity.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Microsoft.Expression.Interactions.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
   </Target>
 </Project>

--- a/Mandrill/app.config
+++ b/Mandrill/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="EO.WebBrowser" publicKeyToken="e92353a6bf73fffc" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-16.2.72.0" newVersion="16.2.72.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.2.98.0" newVersion="15.2.98.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Mandrill/packages.config
+++ b/Mandrill/packages.config
@@ -11,7 +11,7 @@
   <package id="HtmlRenderer.PdfSharp" version="1.5.0.6" targetFramework="net452" />
   <package id="HtmlRenderer.WinForms" version="1.5.0.6" targetFramework="net452" />
   <package id="HtmlRenderer.WPF" version="1.5.0.6" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="NUnit" version="2.6.3" targetFramework="net452" />
   <package id="PDFsharp" version="1.32.3057.0" targetFramework="net452" />
   <package id="Prism" version="4.1.0.0" targetFramework="net452" />

--- a/Mandrill_Grasshopper/Mandrill_Grasshopper.csproj
+++ b/Mandrill_Grasshopper/Mandrill_Grasshopper.csproj
@@ -65,21 +65,18 @@
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EO.Base, Version=16.2.72.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
-      <HintPath>..\packages\EO.WebBrowser.16.2.72.0\lib\EO.Base.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EO.Base, Version=16.2.50.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
+      <HintPath>..\packages\EO.WebBrowser.16.2.50.0\lib\EO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="EO.WebBrowser, Version=16.2.72.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
-      <HintPath>..\packages\EO.WebBrowser.16.2.72.0\lib\EO.WebBrowser.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EO.WebBrowser, Version=16.2.50.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
+      <HintPath>..\packages\EO.WebBrowser.16.2.50.0\lib\EO.WebBrowser.dll</HintPath>
     </Reference>
-    <Reference Include="EO.WebBrowser.Wpf, Version=16.2.72.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
+    <Reference Include="EO.WebBrowser.Wpf, Version=16.2.50.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EO.WebBrowser.16.2.72.0\lib\EO.WebBrowser.Wpf.dll</HintPath>
+      <HintPath>..\packages\EO.WebBrowser.16.2.50.0\lib\EO.WebBrowser.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="EO.WebEngine, Version=16.2.72.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
-      <HintPath>..\packages\EO.WebBrowser.16.2.72.0\lib\EO.WebEngine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EO.WebEngine, Version=16.2.50.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
+      <HintPath>..\packages\EO.WebBrowser.16.2.50.0\lib\EO.WebEngine.dll</HintPath>
     </Reference>
     <Reference Include="GH_IO, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a29997d2e6b4f97, processorArchitecture=MSIL">
       <HintPath>..\packages\Grasshopper.0.9.76\lib\net35\GH_IO.dll</HintPath>
@@ -95,6 +92,7 @@
     </Reference>
     <Reference Include="Mandrill_License">
       <HintPath>..\packages\build\Mandrill_License.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="PresentationCore" />
@@ -202,11 +200,12 @@
     <ProjectReference Include="..\Mandrill_d3\Mandrill_d3.csproj">
       <Project>{63ed27cd-0302-4240-b322-990e76dbac42}</Project>
       <Name>Mandrill_d3</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Mandrill_Resources\Mandrill_Resources.csproj">
       <Project>{4e895fa3-4332-4345-b714-7d57a2bebb3b}</Project>
       <Name>Mandrill_Resources</Name>
-      <Private>True</Private>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -257,6 +256,13 @@ xcopy /Q/Y "$(TargetDir)$(TargetName).gha" "%25AppData%25\Grasshopper\Libraries\
     <Error Condition="!Exists('..\packages\Select.HtmlToPdf.2.3.0.0\build\Select.HtmlToPdf.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Select.HtmlToPdf.2.3.0.0\build\Select.HtmlToPdf.targets'))" />
     <Error Condition="!Exists('..\packages\RhinoCommon.5.12.50810.13095\build\net35\RhinoCommon.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\RhinoCommon.5.12.50810.13095\build\net35\RhinoCommon.targets'))" />
     <Error Condition="!Exists('..\packages\Grasshopper.0.9.76\build\net35\Grasshopper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grasshopper.0.9.76\build\net35\Grasshopper.targets'))" />
+  </Target>
+  <Target Name="CopyFiles" AfterTargets="AfterBuild;NonWinFodyTarget">
+    <Message Text="Copy files..." Importance="high" />
+    <Message Text="" Importance="high" />
+    <Message Text="$(TargetPath) copied to Dynamo\Packages" Importance="high" />
+    <Message Text="$(TargetPath) copied to Grasshopper\\Libraries" Importance="high" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).gha" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
   </Target>
   <Import Project="..\packages\RhinoCommon.5.12.50810.13095\build\net35\RhinoCommon.targets" Condition="Exists('..\packages\RhinoCommon.5.12.50810.13095\build\net35\RhinoCommon.targets')" />
   <Import Project="..\packages\Grasshopper.0.9.76\build\net35\Grasshopper.targets" Condition="Exists('..\packages\Grasshopper.0.9.76\build\net35\Grasshopper.targets')" />

--- a/Mandrill_Grasshopper/app.config
+++ b/Mandrill_Grasshopper/app.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="EO.WebBrowser" publicKeyToken="e92353a6bf73fffc" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-16.2.72.0" newVersion="16.2.72.0"/>
+        <assemblyIdentity name="EO.WebBrowser" publicKeyToken="e92353a6bf73fffc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-16.2.72.0" newVersion="16.2.72.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="RhinoCommon" publicKeyToken="552281e97c755530" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.1.30000.16" newVersion="5.1.30000.16"/>
+        <assemblyIdentity name="RhinoCommon" publicKeyToken="552281e97c755530" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.1.30000.16" newVersion="5.1.30000.16" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Mandrill_Grasshopper/packages.config
+++ b/Mandrill_Grasshopper/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EO.WebBrowser" version="16.2.72.0" targetFramework="net452" />
+  <package id="EO.WebBrowser" version="16.2.50.0" targetFramework="net46" />
   <package id="Grasshopper" version="0.9.76" targetFramework="net452" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
   <package id="RhinoCommon" version="5.12.50810.13095" targetFramework="net452" />

--- a/Mandrill_Resources/Mandrill_Resources.csproj
+++ b/Mandrill_Resources/Mandrill_Resources.csproj
@@ -282,8 +282,17 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Q/Y "$(TargetPath)" "%25AppData%25\Grasshopper\Libraries\Mandrill"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
+  <Target Name="CopyFiles" AfterTargets="AfterBuild;NonWinFodyTarget">
+    <Message Text="Copy files..." Importance="high" />
+    <Message Text="" Importance="high" />
+    <Message Text="$(TargetPath) copied to Dynamo\Packages" Importance="high" />
+    <Message Text="$(TargetPath) copied to Grasshopper\\Libraries" Importance="high" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Mandrill_Types/Mandrill_Types.csproj
+++ b/Mandrill_Types/Mandrill_Types.csproj
@@ -138,7 +138,7 @@
   <ItemGroup>
     <Reference Include="DynamoServices, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.2.0.0.4714\lib\net45\DynamoServices.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -157,6 +157,7 @@
     <ProjectReference Include="..\Mandrill_d3\Mandrill_d3.csproj">
       <Project>{63ed27cd-0302-4240-b322-990e76dbac42}</Project>
       <Name>Mandrill_d3</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -164,8 +165,18 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Q/Y "$(TargetPath)" "%25AppData%25\Grasshopper\Libraries\Mandrill"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
+  <Target Name="CopyFiles" AfterTargets="AfterBuild;NonWinFodyTarget">
+    <Message Text="Copy files..." Importance="high" />
+    <Message Text="" Importance="high" />
+    <Message Text="$(TargetPath) copied to Dynamo\Packages" Importance="high" />
+    <Message Text="$(TargetPath) copied to Grasshopper\\Libraries" Importance="high" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).xml" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Mandrill_UI/Controls/MandrillWindow.xaml.cs
+++ b/Mandrill_UI/Controls/MandrillWindow.xaml.cs
@@ -1,10 +1,9 @@
-﻿
-namespace Mandrill.ChromeWindow
+﻿namespace Mandrill.ChromeWindow
 {
     /// <summary>
-    ///     Interaction logic for MandrillWindow.xaml
+    /// Interaction logic for MandrillWindow.xaml
     /// </summary>
-    public partial class MandrillWindow : System.Windows.Window
+    public partial class MandrillWindow
     {
         /// <summary>
         ///     Mandrill Window class.
@@ -14,20 +13,24 @@ namespace Mandrill.ChromeWindow
             InitializeComponent();
 
             // make a license request
-            Mandrill.Authentication.License.RequestLicense();
+            Authentication.License.RequestLicense();
 
             // set webbroser options
             //options.AllowJavaScript = false;
             //options.DefaultEncoding = System.Text.Encoding.UTF8;
-            EO.WebEngine.BrowserOptions options = new EO.WebEngine.BrowserOptions();
-            options.EnableWebSecurity = false;
-            this.browser.WebView.SetOptions(options);
+            // (Konrad) These options are critical for the app to work. 
+            // We can load d3.js file and other resource only if security is disabled.
+            var options = new EO.WebEngine.BrowserOptions
+            {
+                EnableWebSecurity = false
+            };
+            browser.WebView.SetOptions(options);
 
             // attach window to dynamo
-            this.Owner = MandrillWindowNodeModel.Dv;
+            Owner = MandrillWindowNodeModel.Dv;
 
             // add closing event
-            this.Closing += MandrillWindowNodeModel.OnWindowClosing;
+            Closing += MandrillWindowNodeModel.OnWindowClosing;
         }
     }
 }

--- a/Mandrill_UI/Controls/MandrillWindowButtonControl.xaml.cs
+++ b/Mandrill_UI/Controls/MandrillWindowButtonControl.xaml.cs
@@ -2,8 +2,14 @@
 
 namespace Mandrill.Window
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public partial class LaunchWindowButtonControl : UserControl
     {
+        /// <summary>
+        /// 
+        /// </summary>
         public LaunchWindowButtonControl()
         {
             InitializeComponent();

--- a/Mandrill_UI/Mandrill_UI.csproj
+++ b/Mandrill_UI/Mandrill_UI.csproj
@@ -146,67 +146,63 @@
   <ItemGroup>
     <Reference Include="CoreNodeModels, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.2.0.0.4714\lib\net45\CoreNodeModels.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="CoreNodeModelsWpf, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.2.0.0.4714\lib\net45\CoreNodeModelsWpf.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DesignScriptBuiltin, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DesignScriptBuiltin.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DSIronPython, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DSIronPython.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoApplications, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoApplications.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCore, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoCore.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoCoreWpf, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.WpfUILibrary.2.0.0.4714\lib\net45\DynamoCoreWpf.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoInstallDetective, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoInstallDetective.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoServices, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.DynamoServices.2.0.0.4714\lib\net45\DynamoServices.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoShapeManager, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoShapeManager.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUnits, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.0.4714\lib\net45\DynamoUnits.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DynamoUtilities, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\DynamoUtilities.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="EO.Base, Version=16.2.72.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
-      <HintPath>..\packages\EO.WebBrowser.16.2.72.0\lib\EO.Base.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EO.Base, Version=16.2.50.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
+      <HintPath>..\packages\EO.WebBrowser.16.2.50.0\lib\EO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="EO.WebBrowser, Version=16.2.72.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
-      <HintPath>..\packages\EO.WebBrowser.16.2.72.0\lib\EO.WebBrowser.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EO.WebBrowser, Version=16.2.50.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
+      <HintPath>..\packages\EO.WebBrowser.16.2.50.0\lib\EO.WebBrowser.dll</HintPath>
     </Reference>
-    <Reference Include="EO.WebBrowser.Wpf, Version=16.2.72.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EO.WebBrowser.16.2.72.0\lib\EO.WebBrowser.Wpf.dll</HintPath>
+    <Reference Include="EO.WebBrowser.Wpf">
+      <HintPath>..\packages\EO.WebBrowser.16.2.50.0\lib\EO.WebBrowser.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="EO.WebEngine, Version=16.2.72.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
-      <HintPath>..\packages\EO.WebBrowser.16.2.72.0\lib\EO.WebEngine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="EO.WebEngine, Version=16.2.50.0, Culture=neutral, PublicKeyToken=e92353a6bf73fffc, processorArchitecture=MSIL">
+      <HintPath>..\packages\EO.WebBrowser.16.2.50.0\lib\EO.WebEngine.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
@@ -221,24 +217,25 @@
     </Reference>
     <Reference Include="Microsoft.Practices.Prism">
       <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Practices.Prism.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="ProtoCore, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\ProtoCore.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="ProtoGeometry, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.0.4714\lib\net45\ProtoGeometry.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Select.HtmlToPdf, Version=2.3.0.0, Culture=neutral, PublicKeyToken=e0ae9f6e27a97018, processorArchitecture=MSIL">
       <HintPath>..\packages\Select.HtmlToPdf.2.3.0.0\lib\net40\Select.HtmlToPdf.dll</HintPath>
@@ -259,7 +256,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="VMDataBridge, Version=2.0.0.4714, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DynamoVisualProgramming.Core.2.0.0.4714\lib\net45\VMDataBridge.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -297,11 +294,12 @@
     <ProjectReference Include="..\Mandrill_d3\Mandrill_d3.csproj">
       <Project>{63ed27cd-0302-4240-b322-990e76dbac42}</Project>
       <Name>Mandrill_d3</Name>
-      <Private>True</Private>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Mandrill_Types\Mandrill_Types.csproj">
       <Project>{cddd1df6-1a31-4960-be81-62fd692f2a82}</Project>
       <Name>Mandrill_Types</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -392,9 +390,8 @@
     <Error Condition="!Exists('..\packages\Select.HtmlToPdf.2.3.0.0\build\Select.HtmlToPdf.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Select.HtmlToPdf.2.3.0.0\build\Select.HtmlToPdf.targets'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Q/Y "$(TargetDir)Mandrill_UI.customization.dll" "%25AppData%25\Roaming\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)HtmlAgilityPack.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetPath)" "%25AppData%25\Grasshopper\Libraries\Mandrill"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <Target Name="BeforeBuild">
     <GetReferenceAssemblyPaths TargetFrameworkMoniker=".NETFramework, Version=v2.0">
@@ -404,5 +401,30 @@ xcopy /Q/Y "$(TargetPath)" "%25AppData%25\Grasshopper\Libraries\Mandrill"</PostB
     <AL TargetType="library" EmbedResources="$(ProjectDir)Mandrill_UIImages.resources" OutputAssembly="$(OutDir)Mandrill_UI.customization.dll" />
   </Target>
   <Target Name="AfterBuild">
+  </Target>
+  <Target Name="CopyFiles" AfterTargets="AfterBuild;NonWinFodyTarget">
+    <Message Text="Copy files..." Importance="high" />
+    <Message Text="" Importance="high" />
+    <Message Text="$(TargetPath) copied to Dynamo\Packages" Importance="high" />
+    <Message Text="$(TargetPath) copied to Grasshopper\\Libraries" Importance="high" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).xml" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).customization.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)EO.Base.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)EO.WebBrowser.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)EO.WebBrowser.Wpf.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)EO.WebEngine.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Newtonsoft.Json.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Select.HtmlToPdf.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Mandrill_License.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlAgilityPack.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)EO.Base.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)EO.WebBrowser.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)EO.WebBrowser.Wpf.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)EO.WebEngine.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Newtonsoft.Json.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Select.HtmlToPdf.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)Mandrill_License.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)HtmlAgilityPack.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
   </Target>
 </Project>

--- a/Mandrill_UI/app.config
+++ b/Mandrill_UI/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="EO.WebBrowser" publicKeyToken="e92353a6bf73fffc" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-16.2.72.0" newVersion="16.2.72.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.2.98.0" newVersion="15.2.98.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Mandrill_UI/packages.config
+++ b/Mandrill_UI/packages.config
@@ -5,9 +5,9 @@
   <package id="DynamoVisualProgramming.DynamoServices" version="2.0.0.4714" targetFramework="net46" />
   <package id="DynamoVisualProgramming.WpfUILibrary" version="2.0.0.4714" targetFramework="net46" />
   <package id="DynamoVisualProgramming.ZeroTouchLibrary" version="2.0.0.4714" targetFramework="net46" />
-  <package id="EO.WebBrowser" version="16.2.72.0" targetFramework="net452" />
+  <package id="EO.WebBrowser" version="16.2.50.0" targetFramework="net46" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="NUnit" version="2.6.3" targetFramework="net452" />
   <package id="Prism" version="4.1.0.0" targetFramework="net452" />
   <package id="Select.HtmlToPdf" version="2.3.0.0" targetFramework="net452" />

--- a/Mandrill_d3/Mandrill_d3.csproj
+++ b/Mandrill_d3/Mandrill_d3.csproj
@@ -197,6 +197,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Select.Html.dep">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ParallelCoordinatesChart\parallelCoordinatesChart.html" />
@@ -233,13 +236,27 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Select.HtmlToPdf.2.3.0.0\build\Select.HtmlToPdf.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Select.HtmlToPdf.2.3.0.0\build\Select.HtmlToPdf.targets'))" />
   </Target>
+  <Target Name="CopyFiles" AfterTargets="AfterBuild;NonWinFodyTarget">
+    <Message Text="Copy files..." Importance="high" />
+    <Message Text="" Importance="high" />
+    <Message Text="$(TargetPath) copied to Dynamo\Packages" Importance="high" />
+    <Message Text="$(TargetPath) copied to Grasshopper\\Libraries" Importance="high" />
+    
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(ProjectDir)Select.Html.dep" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)LumenWorks.Framework.IO.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)RazorEngine.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)System.Web.Razor.dll" DestinationFolder="$(APPDATA)\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin" ContinueOnError="true" />
+    
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(ProjectDir)Select.Html.dep" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)LumenWorks.Framework.IO.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)RazorEngine.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+    <Copy SourceFiles="$(TargetDir)System.Web.Razor.dll" DestinationFolder="$(APPDATA)\Grasshopper\Libraries\Mandrill" ContinueOnError="true" />
+  </Target>
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Q/Y "$(TargetDir)System.Web.Razor.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)LumenWorks.Framework.IO.dll" "%25AppData%25\Dynamo\Dynamo Revit\2.0\packages\Archi-lab_Mandrill\bin"
-xcopy /Q/Y "$(TargetDir)System.Web.Razor.dll" "%25AppData%25\Grasshopper\Libraries\Mandrill"
-xcopy /Q/Y "$(TargetDir)RazorEngine.dll" "%25AppData%25\Grasshopper\Libraries\Mandrill"
-xcopy /Q/Y "$(TargetPath)" "%25AppData%25\Grasshopper\Libraries\Mandrill"
-xcopy /Q/Y "$(TargetDir)LumenWorks.Framework.IO.dll" "%25AppData%25\Grasshopper\Libraries\Mandrill"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
OK so I tested Costura.Fody and still no luck with EO.WebBrowser. 

There is a package in Revit that gets loaded called Analysis something. It uses EO.WebBrowser ver. 15.2.98. I don't have an issue with it except that I cannot use it because it doesn't have options for disabling browser security that I need. So I need at least a version 16.2.50 for it to work. Bummer. 

Also, this should be fixed. https://github.com/BadMonkeysTeam/Mandrill/issues/51 This Dynamo 2.0 updates strongly depend on Newtonsoft v. 8.0.3. I had a newer version so the inputs were behaving strange. 

